### PR TITLE
Namespace Prefix Error Patch

### DIFF
--- a/img-contact-block.php
+++ b/img-contact-block.php
@@ -26,7 +26,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function imagewize_contact_block_init() {
-	register_block_type( __DIR__ . '/build/img-contact-block' );
+	// Register the block using the block.json metadata from build directory
+	register_block_type( __DIR__ . '/build/img-contact-block', array(
+		'editor_script' => 'img-contact-block-editor-script',
+		'editor_style'  => 'img-contact-block-editor-style',
+		'style'         => 'img-contact-block-style',
+		'render_callback' => 'imagewize_contact_block_render_callback',
+	) );
 	
 	// Enqueue script data
 	add_action( 'wp_enqueue_scripts', 'img_contact_block_enqueue_view_script_data' );
@@ -34,6 +40,14 @@ function imagewize_contact_block_init() {
 	// Register AJAX handlers
 	add_action( 'wp_ajax_img_contact_form_submission', 'img_contact_form_submission_handler' );
 	add_action( 'wp_ajax_nopriv_img_contact_form_submission', 'img_contact_form_submission_handler' );
+}
+
+/**
+ * Render callback function
+ */
+function imagewize_contact_block_render_callback( $attributes, $content ) {
+	// You can add server-side rendering code here if needed
+	return $content;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "contact-block",
+	"name": "img-contact-block",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "contact-block",
+			"name": "img-contact-block",
 			"version": "0.1.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {


### PR DESCRIPTION
This pull request includes changes to the `img-contact-block.php` file to enhance the registration and rendering of the contact block. The most important changes include adding metadata for the block registration and introducing a render callback function.

Enhancements to block registration:

* [`img-contact-block.php`](diffhunk://#diff-f42739dd274e32e00020eac7da0b9b1d0261817fffa44bc49d18c4b895ff14f6L29-R35): Updated the `register_block_type` function to include metadata such as `editor_script`, `editor_style`, `style`, and `render_callback`.

Introduction of render callback function:

* [`img-contact-block.php`](diffhunk://#diff-f42739dd274e32e00020eac7da0b9b1d0261817fffa44bc49d18c4b895ff14f6R45-R52): Added the `imagewize_contact_block_render_callback` function to handle server-side rendering if needed.