### PR TITLE
Register Block Type Patch

### DIFF
--- a/img-contact-block.php
+++ b/img-contact-block.php
@@ -26,13 +26,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function imagewize_contact_block_init() {
-	// Register the block using the block.json metadata from build directory
-	register_block_type( __DIR__ . '/build/img-contact-block', array(
-		'editor_script' => 'img-contact-block-editor-script',
-		'editor_style'  => 'img-contact-block-editor-style',
-		'style'         => 'img-contact-block-style',
-		'render_callback' => 'imagewize_contact_block_render_callback',
-	) );
+	// Option 1: Register using block.json from build directory (preferred)
+	register_block_type( __DIR__ . '/build/contact-block' );
+	
+	// Option 2: If the above doesn't work, register with direct namespace
+	// register_block_type( 'imagewize/img-contact-block', array(
+	//     'editor_script' => 'img-contact-block-editor-script',
+	//     'editor_style'  => 'img-contact-block-editor-style',
+	//     'style'         => 'img-contact-block-style',
+	//     'render_callback' => 'imagewize_contact_block_render_callback',
+	// ) );
 	
 	// Enqueue script data
 	add_action( 'wp_enqueue_scripts', 'img_contact_block_enqueue_view_script_data' );
@@ -55,7 +58,7 @@ function imagewize_contact_block_render_callback( $attributes, $content ) {
  */
 function img_contact_block_enqueue_view_script_data() {
 	wp_localize_script(
-		'imagewize-img-contact-block-view-script',
+		'img-contact-block-view-script',  // Updated script handle to match block.json
 		'imgContactFormData',
 		array(
 			'ajaxUrl' => admin_url( 'admin-ajax.php' ),


### PR DESCRIPTION
This pull request includes updates to the `img-contact-block.php` file, focusing on improving the registration process of the contact block and updating the script handle to match the block.json metadata.

Improvements to block registration:

* [`img-contact-block.php`](diffhunk://#diff-f42739dd274e32e00020eac7da0b9b1d0261817fffa44bc49d18c4b895ff14f6L29-R38): Updated the `imagewize_contact_block_init` function to provide two options for registering the block, with a preference for using the block.json metadata from the build directory. The second option, using a direct namespace, is commented out as a fallback.

Updates to script handle:

* [`img-contact-block.php`](diffhunk://#diff-f42739dd274e32e00020eac7da0b9b1d0261817fffa44bc49d18c4b895ff14f6L58-R61): Changed the script handle in the `img_contact_block_enqueue_view_script_data` function to match the block.json metadata, ensuring consistency.